### PR TITLE
Update deployment for Blood Type Information Detail Module

### DIFF
--- a/src/database/entities/Blood.entity.ts
+++ b/src/database/entities/Blood.entity.ts
@@ -69,3 +69,34 @@ export class BloodTypeInfo {
   @Property({ type: 'text', nullable: true })
   specialNotes?: string; // Ghi chú đặc biệt
 }
+
+@Entity()
+export class BloodTypeInfoDetail {
+  @PrimaryKey()
+  @Enum(() => BloodGroup)
+  name: BloodGroup;
+
+  @Property({ type: 'text' })
+  groupName: string; // e.g., "Group A", "Group B"
+
+  @Property({ type: 'text' })
+  description: string;
+
+  @Property()
+  redCellsHeight: number;
+
+  @Property()
+  plasmaHeight: number;
+
+  @Property({ type: 'json' })
+  antigens: string[];
+
+  @Property({ type: 'json' })
+  antibodies: string[];
+
+  @Property({ type: 'json' })
+  canDonateTo: string[];
+
+  @Property({ type: 'json' })
+  canReceiveFrom: string[];
+}

--- a/src/database/migrations/.snapshot-postgres.json
+++ b/src/database/migrations/.snapshot-postgres.json
@@ -24,7 +24,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -35,7 +35,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "email": {
@@ -112,7 +112,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -123,7 +123,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "account_id": {
@@ -218,7 +218,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -229,7 +229,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "title": {
@@ -618,6 +618,109 @@
     },
     {
       "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "red_cells_height": {
+          "name": "red_cells_height",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "integer"
+        },
+        "plasma_height": {
+          "name": "plasma_height",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "integer"
+        },
+        "antigens": {
+          "name": "antigens",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "json"
+        },
+        "antibodies": {
+          "name": "antibodies",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "json"
+        },
+        "can_donate_to": {
+          "name": "can_donate_to",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "json"
+        },
+        "can_receive_from": {
+          "name": "can_receive_from",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "json"
+        }
+      },
+      "name": "blood_type_info_detail",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "blood_type_info_detail_pkey",
+          "columnNames": [
+            "name"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
         "id": {
           "name": "id",
           "type": "varchar(255)",
@@ -636,7 +739,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -647,7 +750,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "name": {
@@ -796,7 +899,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -807,7 +910,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "account_id": {
@@ -1084,7 +1187,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -1095,7 +1198,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "campaign_id": {
@@ -1133,7 +1236,8 @@
             "result_returned",
             "appointment_confirmed",
             "appointment_cancelled",
-            "appointment_absent"
+            "appointment_absent",
+            "customer_cancelled"
           ],
           "mappedType": "enum"
         },
@@ -1211,7 +1315,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -1222,7 +1326,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "member_id": {
@@ -1378,7 +1482,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -1389,7 +1493,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "requested_by_id": {
@@ -1667,7 +1771,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -1678,7 +1782,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "account_id": {
@@ -1873,7 +1977,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -1884,7 +1988,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "account_id": {
@@ -1992,7 +2096,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -2003,7 +2107,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "emergency_request_id": {
@@ -2135,7 +2239,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -2146,7 +2250,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "campaign_donation_id": {
@@ -2264,7 +2368,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -2275,7 +2379,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "campaign_donation_id": {
@@ -2302,7 +2406,8 @@
             "result_returned",
             "appointment_confirmed",
             "appointment_cancelled",
-            "appointment_absent"
+            "appointment_absent",
+            "customer_cancelled"
           ],
           "mappedType": "enum"
         },
@@ -2392,7 +2497,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -2403,7 +2508,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-06-27T11:40:08.366Z'",
+          "default": "'2025-07-01T09:40:57.626Z'",
           "mappedType": "datetime"
         },
         "blood_unit_id": {

--- a/src/database/migrations/Migration20250701094057_update_blood_type_info_detail_entity.ts
+++ b/src/database/migrations/Migration20250701094057_update_blood_type_info_detail_entity.ts
@@ -1,0 +1,165 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20250701094057_update_blood_type_info_detail_entity extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table "blood_type_info_detail" ("name" varchar(255) not null, "group_name" text not null, "description" text not null, "red_cells_height" int not null, "plasma_height" int not null, "antigens" jsonb not null, "antibodies" jsonb not null, "can_donate_to" jsonb not null, "can_receive_from" jsonb not null, constraint "blood_type_info_detail_pkey" primary key ("name"));`);
+
+    this.addSql(`alter table "campaign_donation" drop constraint if exists "campaign_donation_current_status_check";`);
+
+    this.addSql(`alter table "campaign_donation_log" drop constraint if exists "campaign_donation_log_status_check";`);
+
+    this.addSql(`alter table "account" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "account" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "account" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "account" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "admin" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "admin" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "admin" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "admin" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "blogs" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blogs" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "blogs" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blogs" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "campaign" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "campaign" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "customer" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "customer" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "customer" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "customer" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "campaign_donation" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "campaign_donation" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "campaign_donation" add constraint "campaign_donation_current_status_check" check("current_status" in ('pending', 'rejected', 'completed', 'result_returned', 'appointment_confirmed', 'appointment_cancelled', 'appointment_absent', 'customer_cancelled'));`);
+
+    this.addSql(`alter table "blood_unit" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "blood_unit" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "emergency_request" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "emergency_request" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "hospital" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "hospital" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "hospital" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "hospital" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "staff" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "staff" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "staff" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "staff" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "emergency_request_log" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request_log" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "emergency_request_log" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request_log" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "donation_result" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "donation_result" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "donation_result" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "donation_result" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+
+    this.addSql(`alter table "campaign_donation_log" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation_log" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "campaign_donation_log" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation_log" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "campaign_donation_log" add constraint "campaign_donation_log_status_check" check("status" in ('pending', 'rejected', 'completed', 'result_returned', 'appointment_confirmed', 'appointment_cancelled', 'appointment_absent', 'customer_cancelled'));`);
+
+    this.addSql(`alter table "blood_unit_actions" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit_actions" alter column "created_at" set default '2025-07-01T09:40:57.626Z';`);
+    this.addSql(`alter table "blood_unit_actions" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit_actions" alter column "updated_at" set default '2025-07-01T09:40:57.626Z';`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "blood_type_info_detail" cascade;`);
+
+    this.addSql(`alter table "campaign_donation" drop constraint if exists "campaign_donation_current_status_check";`);
+
+    this.addSql(`alter table "campaign_donation_log" drop constraint if exists "campaign_donation_log_status_check";`);
+
+    this.addSql(`alter table "account" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "account" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "account" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "account" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "admin" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "admin" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "admin" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "admin" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "blogs" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blogs" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "blogs" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blogs" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "campaign" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "campaign" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "customer" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "customer" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "customer" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "customer" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "campaign_donation" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "campaign_donation" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "campaign_donation" add constraint "campaign_donation_current_status_check" check("current_status" in ('pending', 'rejected', 'completed', 'result_returned', 'appointment_confirmed', 'appointment_cancelled', 'appointment_absent'));`);
+
+    this.addSql(`alter table "blood_unit" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "blood_unit" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "emergency_request" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "emergency_request" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "hospital" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "hospital" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "hospital" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "hospital" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "staff" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "staff" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "staff" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "staff" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "emergency_request_log" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request_log" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "emergency_request_log" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request_log" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "donation_result" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "donation_result" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "donation_result" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "donation_result" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+
+    this.addSql(`alter table "campaign_donation_log" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation_log" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "campaign_donation_log" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation_log" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "campaign_donation_log" add constraint "campaign_donation_log_status_check" check("status" in ('pending', 'rejected', 'completed', 'result_returned', 'appointment_confirmed', 'appointment_cancelled', 'appointment_absent'));`);
+
+    this.addSql(`alter table "blood_unit_actions" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit_actions" alter column "created_at" set default '2025-06-27T11:40:08.366Z';`);
+    this.addSql(`alter table "blood_unit_actions" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit_actions" alter column "updated_at" set default '2025-06-27T11:40:08.366Z';`);
+  }
+
+}

--- a/src/database/seeders/db.seeder.ts
+++ b/src/database/seeders/db.seeder.ts
@@ -7,6 +7,7 @@ import {
   BloodType,
   BloodComponentType,
   BloodTypeInfo,
+  BloodTypeInfoDetail,
 } from '../entities/Blood.entity';
 
 export class DatabaseSeeder extends Seeder {
@@ -43,12 +44,20 @@ export class DatabaseSeeder extends Seeder {
       bloodTypeEntities = await em.find(BloodType, {});
     }
 
-    // Check if BloodTypeInfo already exists
+    // Check if BloodTypeInfos already exists
     const existingBloodTypeInfos = await em.count(BloodTypeInfo);
     if (existingBloodTypeInfos === 0) {
       // Create BloodTypeInfo entities with descriptions
       const bloodTypeInfos = this.createBloodTypeInfos();
       await em.persistAndFlush(bloodTypeInfos);
+    }
+
+    // Check if BloodTypeInfoDetail already exists
+    const existingBloodTypeInfoDetails = await em.count(BloodTypeInfoDetail);
+    if (existingBloodTypeInfoDetails === 0) {
+      // Create BloodTypeInfoDetail entities
+      const bloodTypeInfoDetails = this.createBloodTypeInfoDetails();
+      await em.persistAndFlush(bloodTypeInfoDetails);
     }
 
     // Check if BloodCompatibility already exists
@@ -225,6 +234,68 @@ export class DatabaseSeeder extends Seeder {
     info.frequency = frequency;
     info.specialNotes = specialNotes;
     return info;
+  }
+
+  private createBloodTypeInfoDetails(): BloodTypeInfoDetail[] {
+    const details: BloodTypeInfoDetail[] = [];
+
+    // Group A
+    const groupA = new BloodTypeInfoDetail();
+    groupA.name = BloodGroup.A;
+    groupA.groupName = 'Nhóm A';
+    groupA.description =
+      'chỉ có kháng nguyên A trên tế bào hồng cầu (và kháng thể B trong huyết tương)';
+    groupA.redCellsHeight = 60;
+    groupA.plasmaHeight = 40;
+    groupA.antigens = ['A'];
+    groupA.antibodies = ['B'];
+    groupA.canDonateTo = ['A', 'AB'];
+    groupA.canReceiveFrom = ['A', 'O'];
+    details.push(groupA);
+
+    // Group B
+    const groupB = new BloodTypeInfoDetail();
+    groupB.name = BloodGroup.B;
+    groupB.groupName = 'Nhóm B';
+    groupB.description =
+      'chỉ có kháng nguyên B trên tế bào hồng cầu (và kháng thể A trong huyết tương)';
+    groupB.redCellsHeight = 55;
+    groupB.plasmaHeight = 45;
+    groupB.antigens = ['B'];
+    groupB.antibodies = ['A'];
+    groupB.canDonateTo = ['B', 'AB'];
+    groupB.canReceiveFrom = ['B', 'O'];
+    details.push(groupB);
+
+    // Group AB
+    const groupAB = new BloodTypeInfoDetail();
+    groupAB.name = BloodGroup.AB;
+    groupAB.groupName = 'Nhóm AB';
+    groupAB.description =
+      'có cả kháng nguyên A và B trên tế bào hồng cầu (nhưng không có kháng thể A hoặc B trong huyết tương)';
+    groupAB.redCellsHeight = 65;
+    groupAB.plasmaHeight = 35;
+    groupAB.antigens = ['A', 'B'];
+    groupAB.antibodies = [];
+    groupAB.canDonateTo = ['AB'];
+    groupAB.canReceiveFrom = ['A', 'B', 'AB', 'O'];
+    details.push(groupAB);
+
+    // Group O
+    const groupO = new BloodTypeInfoDetail();
+    groupO.name = BloodGroup.O;
+    groupO.groupName = 'Nhóm O';
+    groupO.description =
+      'không có kháng nguyên A hoặc B trên tế bào hồng cầu (nhưng có cả kháng thể A và B trong huyết tương)';
+    groupO.redCellsHeight = 50;
+    groupO.plasmaHeight = 50;
+    groupO.antigens = [];
+    groupO.antibodies = ['A', 'B'];
+    groupO.canDonateTo = ['A', 'B', 'AB', 'O'];
+    groupO.canReceiveFrom = ['O'];
+    details.push(groupO);
+
+    return details;
   }
 
   // Compatibility logic methods (copied from inventory service)

--- a/src/modules/blood-info/blood-info.controller.ts
+++ b/src/modules/blood-info/blood-info.controller.ts
@@ -182,4 +182,41 @@ export class BloodInfoController {
       componentType,
     );
   }
+
+  @Get('details')
+  @ApiOperation({
+    summary: 'Get all blood type details for frontend',
+    description:
+      'Retrieve blood type details in the format expected by frontend',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully retrieved all blood type details',
+  })
+  async getAllBloodTypeDetails(): Promise<Record<string, any>> {
+    return this.bloodInfoService.getAllBloodTypeDetails();
+  }
+
+  @Get('details/:group')
+  @ApiOperation({
+    summary: 'Get specific blood type detail for frontend',
+    description:
+      'Retrieve specific blood type detail in the format expected by frontend',
+  })
+  @ApiParam({
+    name: 'group',
+    enum: BloodGroup,
+    description: 'Blood group (A, B, AB, O)',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully retrieved blood type detail',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Blood type detail not found',
+  })
+  async getBloodTypeDetail(@Param('group') group: BloodGroup): Promise<any> {
+    return this.bloodInfoService.getBloodTypeDetail(group);
+  }
 }

--- a/src/modules/blood-info/blood-info.service.ts
+++ b/src/modules/blood-info/blood-info.service.ts
@@ -6,6 +6,7 @@ import {
   BloodGroup,
   BloodRh,
   BloodComponentType,
+  BloodTypeInfoDetail,
 } from '../../database/entities/Blood.entity';
 import { IBloodInfoService } from './interfaces/blood-info.service.interface';
 import {
@@ -233,5 +234,63 @@ export class BloodInfoService implements IBloodInfoService {
       frequency: bloodTypeInfo.frequency,
       specialNotes: bloodTypeInfo.specialNotes,
     };
+  }
+
+  async getAllBloodTypeDetails(): Promise<Record<string, any>> {
+    try {
+      const bloodTypeDetails = await this.em.find(BloodTypeInfoDetail, {});
+
+      const result: Record<string, any> = {};
+
+      bloodTypeDetails.forEach((detail) => {
+        result[detail.name] = {
+          name: detail.groupName,
+          description: detail.description,
+          redCellsHeight: detail.redCellsHeight,
+          plasmaHeight: detail.plasmaHeight,
+          antigens: detail.antigens,
+          antibodies: detail.antibodies,
+          canDonateTo: detail.canDonateTo,
+          canReceiveFrom: detail.canReceiveFrom,
+        };
+      });
+
+      return result;
+    } catch (error: any) {
+      this.logger.error(
+        `Error getting all blood type details: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
+  }
+
+  async getBloodTypeDetail(group: BloodGroup): Promise<any> {
+    try {
+      const bloodTypeDetail = await this.em.findOne(BloodTypeInfoDetail, {
+        name: group,
+      });
+
+      if (!bloodTypeDetail) {
+        throw new NotFoundException(`Blood type detail for ${group} not found`);
+      }
+
+      return {
+        name: bloodTypeDetail.groupName,
+        description: bloodTypeDetail.description,
+        redCellsHeight: bloodTypeDetail.redCellsHeight,
+        plasmaHeight: bloodTypeDetail.plasmaHeight,
+        antigens: bloodTypeDetail.antigens,
+        antibodies: bloodTypeDetail.antibodies,
+        canDonateTo: bloodTypeDetail.canDonateTo,
+        canReceiveFrom: bloodTypeDetail.canReceiveFrom,
+      };
+    } catch (error: any) {
+      this.logger.error(
+        `Error getting blood type detail for ${group}: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
   }
 }

--- a/src/modules/blood-info/interfaces/blood-info.service.interface.ts
+++ b/src/modules/blood-info/interfaces/blood-info.service.interface.ts
@@ -48,4 +48,14 @@ export interface IBloodInfoService {
     donorRh: BloodRh,
     componentType: BloodComponentType,
   ): Promise<BloodInfoResponseDto[]>;
+
+  /**
+   * Get all blood type details in frontend format
+   */
+  getAllBloodTypeDetails(): Promise<Record<string, any>>;
+
+  /**
+   * Get specific blood type detail in frontend format
+   */
+  getBloodTypeDetail(group: BloodGroup): Promise<any>;
 }


### PR DESCRIPTION
This pull request introduces a new `BloodTypeInfoDetail` entity and updates the database schema to reflect this addition. It also includes modifications to default datetime values and updates to an enum in the database schema.

### New Entity Addition:
* [`src/database/entities/Blood.entity.ts`](diffhunk://#diff-94f8b57efd2a38b1d43b2eb91641261d69fab3727527473e42c1cc5cbdbba28dR72-R102): Added a new `BloodTypeInfoDetail` entity with properties such as `name`, `groupName`, `description`, `redCellsHeight`, `plasmaHeight`, `antigens`, `antibodies`, `canDonateTo`, and `canReceiveFrom`. This entity provides detailed information about blood types.

* [`src/database/migrations/.snapshot-postgres.json`](diffhunk://#diff-e6e6d8fb49e2996c5e156bc3dea883d17af2c7ed9c0d27cd209b8fe6428ac84eR619-R721): Added the corresponding table definition for the `BloodTypeInfoDetail` entity, including its columns, data types, and primary key.

### Schema Updates:
* [`src/database/migrations/.snapshot-postgres.json`](diffhunk://#diff-e6e6d8fb49e2996c5e156bc3dea883d17af2c7ed9c0d27cd209b8fe6428ac84eL27-R27): Updated default values for multiple `datetime` fields across various tables to a new timestamp, `'2025-07-01T09:40:57.626Z'`. These changes ensure consistency in the database schema. [[1]](diffhunk://#diff-e6e6d8fb49e2996c5e156bc3dea883d17af2c7ed9c0d27cd209b8fe6428ac84eL27-R27) [[2]](diffhunk://#diff-e6e6d8fb49e2996c5e156bc3dea883d17af2c7ed9c0d27cd209b8fe6428ac84eL38-R38) and multiple other references)

### Enum Modification:
* [`src/database/migrations/.snapshot-postgres.json`](diffhunk://#diff-e6e6d8fb49e2996c5e156bc3dea883d17af2c7ed9c0d27cd209b8fe6428ac84eL1136-R1240): Added a new value, `customer_cancelled`, to an existing enum used in the database schema. This likely supports a new state or feature related to customer actions. [[1]](diffhunk://#diff-e6e6d8fb49e2996c5e156bc3dea883d17af2c7ed9c0d27cd209b8fe6428ac84eL1136-R1240) [[2]](diffhunk://#diff-e6e6d8fb49e2996c5e156bc3dea883d17af2c7ed9c0d27cd209b8fe6428ac84eL2305-R2410)