### PR TITLE
Emergency Fix and Campaign Donation field added

### DIFF
--- a/src/database/entities/campaign.entity.ts
+++ b/src/database/entities/campaign.entity.ts
@@ -1,4 +1,5 @@
 import { Entity, Enum, ManyToOne, Property } from '@mikro-orm/core';
+
 import { Customer, Staff } from './Account.entity';
 import { AppBaseEntity } from './base.entity';
 import { BloodGroup, BloodRh } from './Blood.entity';
@@ -71,6 +72,9 @@ export class CampaignDonation extends AppBaseEntity {
 
   @Property({ nullable: true })
   appointmentDate?: Date;
+
+  @Property({ nullable: true, default: false })
+  isBloodUnitCreated: boolean;
 }
 
 @Entity()

--- a/src/database/migrations/.snapshot-postgres.json
+++ b/src/database/migrations/.snapshot-postgres.json
@@ -24,7 +24,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -35,7 +35,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "email": {
@@ -112,7 +112,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -123,7 +123,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "account_id": {
@@ -229,7 +229,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -240,7 +240,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "title": {
@@ -750,7 +750,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -761,7 +761,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "name": {
@@ -910,7 +910,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -921,7 +921,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "account_id": {
@@ -1241,7 +1241,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -1252,7 +1252,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "campaign_id": {
@@ -1314,6 +1314,16 @@
           "nullable": true,
           "length": 6,
           "mappedType": "datetime"
+        },
+        "is_blood_unit_created": {
+          "name": "is_blood_unit_created",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "default": "false",
+          "mappedType": "boolean"
         }
       },
       "name": "campaign_donation",
@@ -1379,7 +1389,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -1390,7 +1400,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "member_id": {
@@ -1583,7 +1593,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -1594,7 +1604,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "donor_id": {
@@ -1711,7 +1721,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -1722,7 +1732,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "requested_by_id": {
@@ -2034,7 +2044,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -2045,7 +2055,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "account_id": {
@@ -2251,7 +2261,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -2262,7 +2272,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "account_id": {
@@ -2382,7 +2392,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -2393,7 +2403,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "emergency_request_id": {
@@ -2553,7 +2563,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -2564,7 +2574,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "campaign_donation_id": {
@@ -2717,7 +2727,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -2728,7 +2738,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "campaign_donation_id": {
@@ -2847,7 +2857,7 @@
           "primary": false,
           "nullable": false,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -2858,7 +2868,7 @@
           "primary": false,
           "nullable": true,
           "length": 6,
-          "default": "'2025-07-27T05:31:33.228Z'",
+          "default": "'2025-07-27T14:41:00.867Z'",
           "mappedType": "datetime"
         },
         "blood_unit_id": {

--- a/src/database/migrations/Migration20250727143506_add_is_blood_unit_created_field.ts
+++ b/src/database/migrations/Migration20250727143506_add_is_blood_unit_created_field.ts
@@ -1,0 +1,159 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20250727143506_add_is_blood_unit_created_field extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "account" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "account" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "account" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "account" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "admin" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "admin" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "admin" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "admin" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "blogs" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blogs" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "blogs" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blogs" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "campaign" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "campaign" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "customer" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "customer" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "customer" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "customer" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "campaign_donation" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "campaign_donation" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "blood_unit" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "blood_unit" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "donation_reminder" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "donation_reminder" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "donation_reminder" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "donation_reminder" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "emergency_request" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "emergency_request" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "hospital" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "hospital" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "hospital" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "hospital" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "staff" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "staff" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "staff" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "staff" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "emergency_request_log" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request_log" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "emergency_request_log" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request_log" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "donation_result" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "donation_result" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "donation_result" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "donation_result" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "campaign_donation_log" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation_log" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "campaign_donation_log" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation_log" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+
+    this.addSql(`alter table "blood_unit_actions" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit_actions" alter column "created_at" set default '2025-07-27T14:35:06.846Z';`);
+    this.addSql(`alter table "blood_unit_actions" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit_actions" alter column "updated_at" set default '2025-07-27T14:35:06.847Z';`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "account" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "account" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "account" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "account" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "admin" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "admin" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "admin" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "admin" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "blogs" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blogs" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "blogs" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blogs" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "campaign" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "campaign" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "customer" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "customer" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "customer" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "customer" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "campaign_donation" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "campaign_donation" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "blood_unit" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "blood_unit" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "donation_reminder" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "donation_reminder" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "donation_reminder" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "donation_reminder" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "emergency_request" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "emergency_request" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "hospital" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "hospital" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "hospital" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "hospital" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "staff" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "staff" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "staff" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "staff" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "emergency_request_log" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request_log" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "emergency_request_log" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "emergency_request_log" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "donation_result" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "donation_result" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "donation_result" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "donation_result" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "campaign_donation_log" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation_log" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "campaign_donation_log" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "campaign_donation_log" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+
+    this.addSql(`alter table "blood_unit_actions" alter column "created_at" type timestamptz using ("created_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit_actions" alter column "created_at" set default '2025-07-27T14:33:31.989Z';`);
+    this.addSql(`alter table "blood_unit_actions" alter column "updated_at" type timestamptz using ("updated_at"::timestamptz);`);
+    this.addSql(`alter table "blood_unit_actions" alter column "updated_at" set default '2025-07-27T14:33:31.989Z';`);
+  }
+
+}

--- a/src/database/migrations/Migration20250727144100_add_is_blood_unit_created_field_manual.ts
+++ b/src/database/migrations/Migration20250727144100_add_is_blood_unit_created_field_manual.ts
@@ -1,0 +1,17 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20250727144100_add_is_blood_unit_created_field_manual extends Migration {
+  override async up(): Promise<void> {
+    // Add isBloodUnitCreated field to campaign_donation table
+    this.addSql(
+      `ALTER TABLE "campaign_donation" ADD COLUMN "is_blood_unit_created" boolean NOT NULL DEFAULT false;`,
+    );
+  }
+
+  override async down(): Promise<void> {
+    // Remove isBloodUnitCreated field from campaign_donation table
+    this.addSql(
+      `ALTER TABLE "campaign_donation" DROP COLUMN "is_blood_unit_created";`,
+    );
+  }
+}

--- a/src/modules/inventory/dtos/blood-unit.dto.ts
+++ b/src/modules/inventory/dtos/blood-unit.dto.ts
@@ -18,6 +18,7 @@ export const createWholeBloodUnitSchema = z.object({
   remainingVolume: z.number().min(0, 'Remaining volume cannot be negative'),
   expiredDate: z.string().or(z.date()),
   staffId: z.string().optional(),
+  donationRequestId: z.string().nonempty('Donation request ID is required'),
 });
 
 export type CreateWholeBloodUnitDtoType = z.infer<

--- a/src/modules/inventory/inventory.module.ts
+++ b/src/modules/inventory/inventory.module.ts
@@ -1,12 +1,13 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 
+import { DonationModule } from '../donation/donation.module';
 import { EmailModule } from '../email/email.module';
 import { BloodUnitNotificationService } from './blood-unit-notification.service';
 import { InventoryController } from './inventory.controller';
 import { InventoryService } from './inventory.service';
 
 @Module({
-  imports: [EmailModule],
+  imports: [EmailModule, forwardRef(() => DonationModule)],
   controllers: [InventoryController],
   providers: [InventoryService, BloodUnitNotificationService],
   exports: [InventoryService, BloodUnitNotificationService],


### PR DESCRIPTION
This pull request introduces a new property, `isBloodUnitCreated`, to the `CampaignDonation` entity and updates default datetime values in the database migration snapshot. These changes aim to enhance the data model for campaign donations and ensure consistency in default timestamps.

### Entity Updates:
* Added a new boolean property, `isBloodUnitCreated`, to the `CampaignDonation` entity with a default value of `false`. This property tracks whether a blood unit has been created for a donation. (`src/database/entities/campaign.entity.ts`, [src/database/entities/campaign.entity.tsR75-R77](diffhunk://#diff-d4dab0994fd1fe4a725a90c112628fc1983935110f556ba5bd4c3f812c71c7bcR75-R77))

### Database Migration Updates:
* Updated multiple default datetime values in the migration snapshot file to reflect a new timestamp (`'2025-07-27T14:41:00.867Z'`) for consistency. (`src/database/migrations/.snapshot-postgres.json`, [[1]](diffhunk://#diff-e6e6d8fb49e2996c5e156bc3dea883d17af2c7ed9c0d27cd209b8fe6428ac84eL27-R27) [[2]](diffhunk://#diff-e6e6d8fb49e2996c5e156bc3dea883d17af2c7ed9c0d27cd209b8fe6428ac84eL38-R38) and others)
* Added the new `is_blood_unit_created` column to the `campaign_donation` table in the migration snapshot, with a default value of `false`. (`src/database/migrations/.snapshot-postgres.json`, [src/database/migrations/.snapshot-postgres.jsonR1317-R1326](diffhunk://#diff-e6e6d8fb49e2996c5e156bc3dea883d17af2c7ed9c0d27cd209b8fe6428ac84eR1317-R1326))